### PR TITLE
2018.10.03

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 - `new-commit` configuration for auto committing when a new project is generated.
 - `update-commit` configuration for auto committing when a project's packages are updated.
+- `version-latest-commit` configuration for auto committing when a project's dependencies are all updated to their latest versions.
 
 ## [2018.09.08]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - `version-latest-commit` configuration for auto committing when a project's dependencies are all updated to their latest versions.
 - `version-set-commit` configuration for auto committing when a project's dependency's version is updated.
 
+### Fixed
+- JSON key used to get license info during package search
+
 ## [2018.09.08]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - `new-commit` configuration for auto committing when a new project is generated.
 - `update-commit` configuration for auto committing when a project's packages are updated.
 - `version-latest-commit` configuration for auto committing when a project's dependencies are all updated to their latest versions.
+- `version-set-commit` configuration for auto committing when a project's dependency's version is updated.
 
 ## [2018.09.08]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Added
 - `new-commit` configuration for auto committing when a new project is generated.
+- `update-commit` configuration for auto committing when a project's packages are updated.
 
 ## [2018.09.08]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [2018.10.03]
+
+### Added
+- `new-commit` configuration for auto committing when a new project is generated.
+
 ## [2018.09.08]
 
 ### Added

--- a/Sources/Ether/Configuration.swift
+++ b/Sources/Ether/Configuration.swift
@@ -36,6 +36,7 @@ public class Configuration: Command {
             "- install-commit: The commit message to use on package install. Use '&0' as package name placeholder",
             "- remove-commit: The commit message to use when a package is removed. Use '&0' as package name placeholder",
             "- new-commit: The commit message to use when a new project is generated. Use '&0' as the project name placeholder",
+            "- update-commit: The commit message to use when a project's packages are updated",
             "- signed-commits: If set to a truthy value (true, yes, y, 1), auto-commits will pass in the '-S' flag"
         ]),
         CommandArgument.argument(name: "value", help: ["The new value for the key passed in. If no value is passed in, the key will be removed from the config"])
@@ -114,6 +115,7 @@ public struct Config: Codable, Reflectable {
     public var installCommit: String?
     public var removeCommit: String?
     public var newCommit: String?
+    public var updateCommit: String?
     public var signedCommits: String?
     
     static let properties: [String: WritableKeyPath<Config, String?>] = [
@@ -121,6 +123,7 @@ public struct Config: Codable, Reflectable {
         "install-commit": \.installCommit,
         "remove-commit": \.removeCommit,
         "new-commit": \.newCommit,
+        "update-commit": \.updateCommit,
         "signed-commits": \.signedCommits
     ]
     

--- a/Sources/Ether/Configuration.swift
+++ b/Sources/Ether/Configuration.swift
@@ -32,7 +32,7 @@ public class Configuration: Command {
         CommandArgument.argument(name: "key", help: [
             "The configuration JSON key to set",
             "Valid keys are:",
-            "- access-token: The GitHub access token to use for interacting the the GraphQL API. You can create on at https://github.com/settings/token",
+            "- access-token: The GitHub access token to use for interacting the the GraphQL API. You can create one at https://github.com/settings/token",
             "- install-commit: The commit message to use on package install. Use '&0' as package name placeholder",
             "- remove-commit: The commit message to use when a package is removed. Use '&0' as package name placeholder",
             "- new-commit: The commit message to use when a new project is generated. Use '&0' as the project name placeholder",

--- a/Sources/Ether/Configuration.swift
+++ b/Sources/Ether/Configuration.swift
@@ -37,6 +37,7 @@ public class Configuration: Command {
             "- remove-commit: The commit message to use when a package is removed. Use '&0' as package name placeholder",
             "- new-commit: The commit message to use when a new project is generated. Use '&0' as the project name placeholder",
             "- update-commit: The commit message to use when a project's packages are updated",
+            "- version-latest-commit: The commit message to use when you update a project's dependencies to their latest versions",
             "- signed-commits: If set to a truthy value (true, yes, y, 1), auto-commits will pass in the '-S' flag"
         ]),
         CommandArgument.argument(name: "value", help: ["The new value for the key passed in. If no value is passed in, the key will be removed from the config"])
@@ -116,6 +117,7 @@ public struct Config: Codable, Reflectable {
     public var removeCommit: String?
     public var newCommit: String?
     public var updateCommit: String?
+    public var latestVersionCommit: String?
     public var signedCommits: String?
     
     static let properties: [String: WritableKeyPath<Config, String?>] = [
@@ -124,6 +126,7 @@ public struct Config: Codable, Reflectable {
         "remove-commit": \.removeCommit,
         "new-commit": \.newCommit,
         "update-commit": \.updateCommit,
+        "version-latest-commit": \.latestVersionCommit,
         "signed-commits": \.signedCommits
     ]
     

--- a/Sources/Ether/Configuration.swift
+++ b/Sources/Ether/Configuration.swift
@@ -38,6 +38,7 @@ public class Configuration: Command {
             "- new-commit: The commit message to use when a new project is generated. Use '&0' as the project name placeholder",
             "- update-commit: The commit message to use when a project's packages are updated",
             "- version-latest-commit: The commit message to use when you update a project's dependencies to their latest versions",
+            "- version-set-commit: The commit message to use when you set a project's dependency to a specific version. Use '&0' as the package name and '&1' as the package's new version placeholders",
             "- signed-commits: If set to a truthy value (true, yes, y, 1), auto-commits will pass in the '-S' flag"
         ]),
         CommandArgument.argument(name: "value", help: ["The new value for the key passed in. If no value is passed in, the key will be removed from the config"])
@@ -118,6 +119,7 @@ public struct Config: Codable, Reflectable {
     public var newCommit: String?
     public var updateCommit: String?
     public var latestVersionCommit: String?
+    public var versionSetCommit: String?
     public var signedCommits: String?
     
     static let properties: [String: WritableKeyPath<Config, String?>] = [
@@ -127,6 +129,7 @@ public struct Config: Codable, Reflectable {
         "new-commit": \.newCommit,
         "update-commit": \.updateCommit,
         "version-latest-commit": \.latestVersionCommit,
+        "version-set-commit": \.versionSetCommit,
         "signed-commits": \.signedCommits
     ]
     

--- a/Sources/Ether/Configuration.swift
+++ b/Sources/Ether/Configuration.swift
@@ -34,7 +34,8 @@ public class Configuration: Command {
             "Valid keys are:",
             "- access-token: The GitHub access token to use for interacting the the GraphQL API. You can create on at https://github.com/settings/token",
             "- install-commit: The commit message to use on package install. Use '&0' as package name placeholder",
-            "- remove-commit: The commit message to use on when a package is removed. Use '&0' as package name placeholder",
+            "- remove-commit: The commit message to use when a package is removed. Use '&0' as package name placeholder",
+            "- new-commit: The commit message to use when a new project is generated. Use '&0' as the project name placeholder",
             "- signed-commits: If set to a truthy value (true, yes, y, 1), auto-commits will pass in the '-S' flag"
         ]),
         CommandArgument.argument(name: "value", help: ["The new value for the key passed in. If no value is passed in, the key will be removed from the config"])
@@ -112,12 +113,14 @@ public struct Config: Codable, Reflectable {
     public var accessToken: String?
     public var installCommit: String?
     public var removeCommit: String?
+    public var newCommit: String?
     public var signedCommits: String?
     
     static let properties: [String: WritableKeyPath<Config, String?>] = [
         "access-token": \.accessToken,
         "install-commit": \.installCommit,
         "remove-commit": \.removeCommit,
+        "new-commit": \.newCommit,
         "signed-commits": \.signedCommits
     ]
     

--- a/Sources/Ether/New.swift
+++ b/Sources/Ether/New.swift
@@ -51,6 +51,11 @@ public final class New: Command {
         }
 
         newProject.succeed()
+        
+        let config = try Configuration.get()
+        let name = try context.argument("name")
+        try config.commit(with: config.newCommit, on: context, replacements: [name])
+        
         return context.container.future()
     }
     

--- a/Sources/Ether/Search.swift
+++ b/Sources/Ether/Search.swift
@@ -70,7 +70,7 @@ public final class Search: Command {
 struct PackageDescription: Codable {
     let nameWithOwner: String
     let description: String?
-    let license: String?
+    let licenseInfo: String?
     let stargazers: Int?
     
     func print(on context: CommandContext) {
@@ -81,7 +81,8 @@ struct PackageDescription: Codable {
             context.console.info(self.nameWithOwner)
         }
         
-        if let license = self.license {
+        if let licenseInfo = self.licenseInfo {
+            let license = licenseInfo == "NOASSERTION" ? "Unknown" : licenseInfo
             context.console.print("License: " + license)
         }
         

--- a/Sources/Ether/Update.swift
+++ b/Sources/Ether/Update.swift
@@ -54,6 +54,9 @@ public final class Update: Command {
             
             updating.succeed()
 
+            let config = try Configuration.get()
+            try config.commit(with: config.updateCommit, on: context, replacements: [])
+            
             if context.options["xcode"] != nil {
                 let xcode = context.console.loadingBar(title: "Generating Xcode Project")
                 _ = xcode.start(on: context.container)

--- a/Sources/Ether/Version/VersionLatest.swift
+++ b/Sources/Ether/Version/VersionLatest.swift
@@ -78,6 +78,9 @@ public final class VersionLatest: Command {
             _ = try Process.execute("swift", "package", "update")
             updating.succeed()
             
+            let config = try Configuration.get()
+            try config.commit(with: config.latestVersionCommit, on: context, replacements: [])
+            
             if let _ = context.options["xcode"] {
                 let xcodeBar = context.console.loadingBar(title: "Generating Xcode Project")
                 _ = xcodeBar.start(on: context.container)

--- a/Sources/Ether/Version/VersionSet.swift
+++ b/Sources/Ether/Version/VersionSet.swift
@@ -64,6 +64,9 @@ public final class VersionSet: Command {
         _ = try Process.execute("swift", "package", "update")
         updating.succeed()
 
+        let config = try Configuration.get()
+        try config.commit(with: config.versionSetCommit, on: context, replacements: [package, version])
+        
         if let _ = context.options["xcode"] {
             let xcodeBar = context.console.loadingBar(title: "Generating Xcode Project")
             _ = xcodeBar.start(on: context.container)

--- a/publish.sh
+++ b/publish.sh
@@ -66,8 +66,9 @@ git add .
 git commit -S -m "Updated Ether version to $TAG"
 git push origin master
 cd ../
-
 rm -rf homebrew-tap
+
+cd Ether/
 rm -rf macOS-sierra.tar.gz
 rm -rf $PACKAGE_NAME
 rm install


### PR DESCRIPTION
### Added
- `new-commit` configuration for auto committing when a new project is generated.
- `update-commit` configuration for auto committing when a project's packages are updated.
- `version-latest-commit` configuration for auto committing when a project's dependencies are all updated to their latest versions.
- `version-set-commit` configuration for auto committing when a project's dependency's version is updated.